### PR TITLE
Use quote_column_name

### DIFF
--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -10,13 +10,13 @@ module SimpleCaptcha
       end
       
       def remove_data(key)
-        delete_all(["`key` = ?", key])
+        delete_all(["#{connection.quote_column_name(:key)} = ?", key])
         clear_old_data(1.hour.ago)
       end
       
       def clear_old_data(time = 1.hour.ago)
         return unless Time === time
-        delete_all(["`updated_at` < ?", time])
+        delete_all(["#{connection.quote_column_name(:updated_at)} < ?", time])
       end
     end
   end


### PR DESCRIPTION
Use quote_column_name function instead of ` to work with all connection adapters.
Current implementation doen't work with PosgreSQL
