### PR TITLE
Patch for Rails 3.1 compatibility

### DIFF
--- a/app/controllers/simple_captcha_controller.rb
+++ b/app/controllers/simple_captcha_controller.rb
@@ -1,5 +1,5 @@
-class SimpleCaptchaController < ActionController::Metal
-  include ActionController::Streaming
+class SimpleCaptchaController < ActionController::Base
+  include ActionController::DataStreaming
   include SimpleCaptcha::ImageHelpers
 
   # GET /simple_captcha


### PR DESCRIPTION
It seems that there are a couple of changes in Rails 3.1 so simple captcha does not work. I found a workaround though: 
I changed  `ActionController::Streaming` to  `ActionController::DataStreaming` because the `send_file` method has moved in 3.1 to `ActionController::DataStreaming`.
The other thing i found out was that response was not set in metal controller (or there is a way to set it that i am not aware of) so i changed `ActionController::Metal` to `ActionController::Base`.
