### PR TITLE
deprecation warnings removed

### DIFF
--- a/lib/simple_captcha/active_record.rb
+++ b/lib/simple_captcha/active_record.rb
@@ -32,8 +32,8 @@ module SimpleCaptcha #:nodoc
       def apply_simple_captcha(options = {})
         options = { :add_to_base => false }.merge(options)
                   
-        write_inheritable_attribute :simple_captcha_options, options
-        class_inheritable_reader :simple_captcha_options
+        class_attribute :simple_captcha_options
+        self.simple_captcha_options = options
         
         unless self.is_a?(ClassMethods)
           include InstanceMethods

--- a/lib/simple_captcha/formtastic.rb
+++ b/lib/simple_captcha/formtastic.rb
@@ -1,5 +1,5 @@
 module SimpleCaptcha
-  class CustomFormBuilder < Formtastic::SemanticFormBuilder
+  class CustomFormBuilder < Formtastic::FormBuilder
 
     private
 


### PR DESCRIPTION
fixed 2 deprecation warnings:
1.  Formtastic::SemanticFormBuilder changed to Formtastic::FormBuilder to use Formtastic 2.0 >
2. class_inheritable_reader changed to class_attribute
