### PR TITLE
Formtastic::SemanticFormHelper is removed use Formtastic::Helpers::FormHelper instead

### DIFF
--- a/lib/simple_captcha/engine.rb
+++ b/lib/simple_captcha/engine.rb
@@ -9,16 +9,16 @@ module SimpleCaptcha
         ActiveRecord::Base.send(:include, SimpleCaptcha::ModelHelpers)
       end
     end
-    
+
     config.after_initialize do
       ActionView::Base.send(:include, SimpleCaptcha::ViewHelper)
       ActionView::Helpers::FormBuilder.send(:include, SimpleCaptcha::FormBuilder)
-      
+
       if Object.const_defined?("Formtastic")
-        Formtastic::SemanticFormHelper.builder = SimpleCaptcha::CustomFormBuilder
+        Formtastic::Helpers::FormHelper.builder = SimpleCaptcha::CustomFormBuilder
       end
     end
-    
+
     config.app_middleware.use SimpleCaptcha::Middleware
   end
 end


### PR DESCRIPTION
you can see it here https://github.com/justinfrench/formtastic/commit/749d7de1b83435178daea2f1151bd534569d03dd
