### PR TITLE
Formtastic class changed from FormBuilder to SemanticFormBuilder

### DIFF
--- a/lib/simple_captcha/engine.rb
+++ b/lib/simple_captcha/engine.rb
@@ -15,7 +15,11 @@ module SimpleCaptcha
       ActionView::Helpers::FormBuilder.send(:include, SimpleCaptcha::FormBuilder)
 
       if Object.const_defined?("Formtastic")
-        Formtastic::Helpers::FormHelper.builder = SimpleCaptcha::CustomFormBuilder
+        if Formtastic.const_defined?("Helpers")
+          Formtastic::Helpers::FormHelper.builder = SimpleCaptcha::CustomFormBuilder
+        else
+          Formtastic::SemanticFormHelper.builder = SimpleCaptcha::CustomFormBuilder
+        end
       end
     end
 

--- a/lib/simple_captcha/formtastic.rb
+++ b/lib/simple_captcha/formtastic.rb
@@ -1,5 +1,5 @@
 module SimpleCaptcha
-  class CustomFormBuilder < Formtastic::FormBuilder
+  class CustomFormBuilder < Formtastic::SemanticFormBuilder
 
     private
 


### PR DESCRIPTION
I was getting this error because of the changes in Formtastic gem:

gems/galetahub-simple_captcha-0.1.2/lib/simple_captcha/formtastic.rb:2:in `module:SimpleCaptcha': uninitialized constant Formtastic::FormBuilder (NameError)
