### PR TITLE
Compatibility for Formtastic 2.0

### DIFF
--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -1,0 +1,7 @@
+if Object.const_defined?("Formtastic")
+  if Formtastic.const_defined?("FormBuilder")
+    CUSTOM_FORM_BASE_CLASS = Formtastic::FormBuilder
+  else
+    CUSTOM_FORM_BASE_CLASS = Formtastic::SemanticFormBuilder
+  end
+end

--- a/lib/simple_captcha/formtastic.rb
+++ b/lib/simple_captcha/formtastic.rb
@@ -1,5 +1,5 @@
 module SimpleCaptcha
-  class CustomFormBuilder < Formtastic::SemanticFormBuilder
+  class CustomFormBuilder < CUSTOM_FORM_BASE_CLASS
 
     private
 


### PR DESCRIPTION
Formtastic::SemanticFormBuilder became Formtastic::FormBuilder
This fix detects which version of Formastic is used and avoids the
deprecation warning
