### PR TITLE
tmp path should be configurable

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -166,6 +166,13 @@ You can provide the path where image_magick is installed as well:
     sc.image_magick_path = '/usr/bin' # you can check this from console by running: which convert
   end
 
+You can provide the path where should be stored tmp files.
+It's usefull when you dont have acces to /tmp (default directory)
+
+  SimpleCaptcha.setup do |sc|
+    sc.tmp_path = '/tmp' # or somewhere in project eg. Rails.root.join('tmp/simple_captcha').to_s, make shure directory exists
+  end
+
 
 ===How to change the CSS for SimpleCaptcha DOM elements?
 You can change the CSS of the SimpleCaptcha DOM elements as per your need in this file.

--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -40,6 +40,10 @@ module SimpleCaptcha
   mattr_accessor :image_magick_path
   @@image_magick_path = ''
 
+  # tmp directory
+  mattr_accessor :tmp_path
+  @@tmp_path = nil
+
   def self.add_image_style(name, params = [])
     SimpleCaptcha::ImageHelpers.image_styles.update(name.to_s => params)
   end

--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -68,7 +68,7 @@ module SimpleCaptcha #:nodoc
         params << "-pointsize 22"
         params << "-implode 0.2"
 
-        dst = RUBY_VERSION < '1.9' ? Tempfile.new('simple_captcha.jpg') : Tempfile.new(['simple_captcha', '.jpg'])
+        dst = Tempfile.new(RUBY_VERSION < '1.9' ? 'simple_captcha.jpg' : ['simple_captcha', '.jpg'], SimpleCaptcha.tmp_path)
         dst.binmode
 
         params << "label:#{text} '#{File.expand_path(dst.path)}'"


### PR DESCRIPTION
You can provide the path where should be stored tmp files.
It's usefull when you dont have acces to /tmp (default directory)

```
SimpleCaptcha.setup do |sc|
  sc.tmp_path = Rails.root.join('tmp/simple_captcha').to_s # make sure directory exists
end
```
