### PR TITLE
Fix set_table_name deprecation warning

### DIFF
--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -5,6 +5,8 @@ module SimpleCaptcha
     end
 
     if rails3?
+      # Fixes deprecation warning in Rails 3.2:
+      # DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead.
       self.table_name = "simple_captcha_data"
     else
       set_table_name "simple_captcha_data"

--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -1,6 +1,14 @@
 module SimpleCaptcha
   class SimpleCaptchaData < ::ActiveRecord::Base
-    set_table_name "simple_captcha_data"
+    def self.rails3?
+      ::ActiveRecord::VERSION::MAJOR == 3
+    end
+
+    if rails3?
+      self.table_name = "simple_captcha_data"
+    else
+      set_table_name "simple_captcha_data"
+    end
     
     attr_accessible :key, :value
     


### PR DESCRIPTION
A quick fix to optionally use `self.table_name` instead of `set_table_name` (which is deprecated in Rails 3.2).
