### PR TITLE
fixes for Rails 3.x and Formtastic 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ spec/dummy/vendor/bundle/
 spec/dummy/app/helpers/manage
 spec/dummy/config/database.yml
 spec/dummy/log/development.log
+.svn

--- a/lib/simple_captcha/active_record.rb
+++ b/lib/simple_captcha/active_record.rb
@@ -59,7 +59,7 @@ module SimpleCaptcha #:nodoc
           return true
         else
           message = simple_captcha_options[:message] || I18n.t(self.class.model_name.downcase, :scope => [:simple_captcha, :message], :default => :default)
-          simple_captcha_options[:add_to_base] ? errors.add_to_base(message) : errors.add(:captcha, message)
+          simple_captcha_options[:add_to_base] ? errors.add(:base, message) : errors.add(:captcha, message)
           return false
         end
       end

--- a/lib/simple_captcha/formtastic.rb
+++ b/lib/simple_captcha/formtastic.rb
@@ -1,5 +1,5 @@
 module SimpleCaptcha
-  class CustomFormBuilder < Formtastic::SemanticFormBuilder
+  class CustomFormBuilder < Formtastic::FormBuilder
 
     private
 


### PR DESCRIPTION
add_to_base is deprecated in Rails 3, and completely removed in Rails 3.2. I have a one-line change that resolves that deprecation error.

In addition, Formtastic 2.1 does not use Formtastic::SemanticFormBuilder, it uses Formtastic::FormBuilder, so I have updated the reference to that class in the appropriate place.

It is important to note that referencing Formtastic::FormBuilder is a stopgap fix, the real fix should be to define a new custom input using the new way that Formtastic opens up and not inheriting from FormBuilder at all. (see the 2.1 Formtastic docs for info, one example of where this new custom input definition is being used is in the active_admin project).
