### PR TITLE
Make simple captcha work on Windows

### DIFF
--- a/lib/simple_captcha/controller.rb
+++ b/lib/simple_captcha/controller.rb
@@ -17,7 +17,7 @@ module SimpleCaptcha #:nodoc
       return true if Rails.env.test?
       
       if params[:captcha]
-        data = SimpleCaptcha::Utils::simple_captcha_value(session[:captcha])
+        data = SimpleCaptcha::Utils::simple_captcha_value(params[:captcha_key] || session[:captcha])
         result = data == params[:captcha].delete(" ").upcase
         SimpleCaptcha::Utils::simple_captcha_passed!(session[:captcha]) if result
         return result

--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -64,14 +64,14 @@ module SimpleCaptcha #:nodoc
         params = ImageHelpers.image_params(SimpleCaptcha.image_style).dup
         params << "-size #{SimpleCaptcha.image_size}"
         params << "-wave #{amplitude}x#{frequency}"
-        params << "-gravity 'Center'"
+        params << "-gravity Center"
         params << "-pointsize 22"
         params << "-implode 0.2"
 
         dst = Tempfile.new(RUBY_VERSION < '1.9' ? 'simple_captcha.jpg' : ['simple_captcha', '.jpg'], SimpleCaptcha.tmp_path)
         dst.binmode
 
-        params << "label:#{text} '#{File.expand_path(dst.path)}'"
+        params << "label:#{text} #{File.expand_path(dst.path)}"
 
         SimpleCaptcha::Utils::run("convert", params.join(' '))
 

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -72,7 +72,8 @@ module SimpleCaptcha #:nodoc
           text_field(options[:object], :captcha, :value => '', :autocomplete => 'off') +
           hidden_field(options[:object], :captcha_key, {:value => options[:field_value]})
         else
-          text_field_tag(:captcha, nil, :autocomplete => 'off')
+          text_field_tag(:captcha, nil, :autocomplete => 'off') +
+          hidden_field_tag(:captcha_key, options[:field_value])
         end
       end
 


### PR DESCRIPTION
When calling ImageMagick simple captcha escapes some parameters with '. That doesn't work on Windows and isn't necessary at all. This pull request removes them - works still on MacOS X.
