### PR TITLE
Update lib/simple_captcha/image.rb

### DIFF
--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -72,7 +72,8 @@ module SimpleCaptcha #:nodoc
         dst = Tempfile.new(RUBY_VERSION < '1.9' ? 'simple_captcha.jpg' : ['simple_captcha', '.jpg'], SimpleCaptcha.tmp_path)
         dst.binmode
 
-        params << "label:#{text} '#{File.expand_path(dst.path)}'"
+        #params << "label:#{text} '#{File.expand_path(dst.path)}'"
+        params << "label:#{text} \"#{File.expand_path(dst.path)}\""
 
         SimpleCaptcha::Utils::run("convert", params.join(' '))
 

--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -64,7 +64,8 @@ module SimpleCaptcha #:nodoc
         params = ImageHelpers.image_params(SimpleCaptcha.image_style).dup
         params << "-size #{SimpleCaptcha.image_size}"
         params << "-wave #{amplitude}x#{frequency}"
-        params << "-gravity 'Center'"
+        #params << "-gravity 'Center'"
+        params << "-gravity \"Center\""
         params << "-pointsize 22"
         params << "-implode 0.2"
 


### PR DESCRIPTION
I am using Ruby 1.9.3 and Rails 3.2.3, i used your gem but captcha image is not displaying,its giving error
StandardError (Error while running convert: convert: unrecognized gravity type `'Center'' @ convert.c/ConvertImageCommand/1508.
): 
and then i realised 'center' in line no. 67 causing this error.so i making this change.

After changing this i am getting error 
StandardError (Error while running convert: convert: no encode delegate for this image format `'C:/AppData/Local/Tem
p/simple_captcha20120731-2740-sfocak.jpg'' @ constitute.c/WriteImage/1114.
so i am making change in line no 75.now its working fine.
