### PR TITLE
Submit captcha_key in hidden_field_tag

### DIFF
--- a/lib/simple_captcha/controller.rb
+++ b/lib/simple_captcha/controller.rb
@@ -17,7 +17,7 @@ module SimpleCaptcha #:nodoc
       return true if Rails.env.test?
       
       if params[:captcha]
-        data = SimpleCaptcha::Utils::simple_captcha_value(session[:captcha])
+        data = SimpleCaptcha::Utils::simple_captcha_value(params[:captcha_key] || session[:captcha])
         result = data == params[:captcha].delete(" ").upcase
         SimpleCaptcha::Utils::simple_captcha_passed!(session[:captcha]) if result
         return result

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -72,7 +72,8 @@ module SimpleCaptcha #:nodoc
           text_field(options[:object], :captcha, :value => '', :autocomplete => 'off') +
           hidden_field(options[:object], :captcha_key, {:value => options[:field_value]})
         else
-          text_field_tag(:captcha, nil, :autocomplete => 'off')
+          text_field_tag(:captcha, nil, :autocomplete => 'off') +
+          hidden_field_tag(:captcha_key, options[:field_value])
         end
       end
 


### PR DESCRIPTION
simple_captcha submits the captcha key (for the DB entry) in the controller based method in the session only. In the model based method, it's submitted in a hidden field. This patch submits the captcha key in a hidden field in the controller based method, too, so it works without cookies.
