### PR TITLE
fix a bug of img src URL of captcha image.

### DIFF
--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -64,7 +64,7 @@ module SimpleCaptcha #:nodoc
         query = defaults.collect{ |key, value| "#{key}=#{value}" }.join('&')
         url = "/simple_captcha?code=#{simple_captcha_key}&#{query}"
         
-        "<img src='#{url}' alt='captcha' />".html_safe
+        image_tag(url, :alt => 'captcha')
       end
       
       def simple_captcha_field(options={})


### PR DESCRIPTION
When we use RailsBaseURI in Passenger,
we hope /base/simple_captcha URL, but got /simple_captcha in img src tag.
We can get correct URL using image_tag instead img src HTML tag.
