### PR TITLE
Fixing problem when using Paperclip

### DIFF
--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -64,7 +64,7 @@ module SimpleCaptcha #:nodoc
         query = defaults.collect{ |key, value| "#{key}=#{value}" }.join('&')
         url = "/simple_captcha?code=#{simple_captcha_key}&#{query}"
         
-        image_tag(url, :alt => 'captcha')
+        tag('img', src: url, :alt => 'captcha')
       end
       
       def simple_captcha_field(options={})

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -64,7 +64,7 @@ module SimpleCaptcha #:nodoc
         query = defaults.collect{ |key, value| "#{key}=#{value}" }.join('&')
         url = "/simple_captcha?code=#{simple_captcha_key}&#{query}"
         
-        tag('img', src: url, :alt => 'captcha')
+        tag('img', :src => url, :alt => 'captcha')
       end
       
       def simple_captcha_field(options={})


### PR DESCRIPTION
If you use some kind of file attachment library like Paperclip, the image_tag method returns another path that is not '/simple_captcha?code=' .
