### PR TITLE
Fix error with image_tag when used with form builder.

### DIFF
--- a/lib/simple_captcha/form_builder.rb
+++ b/lib/simple_captcha/form_builder.rb
@@ -3,6 +3,9 @@ module SimpleCaptcha
     def self.included(base)
       base.send(:include, SimpleCaptcha::ViewHelper)
       base.send(:include, SimpleCaptcha::FormBuilder::ClassMethods)
+      base.send(:include, ActionView::Helpers)
+      base.send(:include, Sprockets::Helpers::RailsHelper)
+      base.send(:include, Sprockets::Helpers::IsolatedHelper)
       
       base.delegate :render, :session, :to => :template
     end


### PR DESCRIPTION
When pull request #25 was merged, required helper includes were not included in the form builder when the `image_tag` helper was referenced from `simple_captcha_image` in `ViewHelper`. This resulted in an undefined method error with `image_tag` when using the form builder method.

The required includes have been added in this pull request which fixes this issue.
