### PR TITLE
Take into account relative root path when generating captcha url

### DIFF
--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -62,7 +62,7 @@ module SimpleCaptcha #:nodoc
         defaults[:time] = options[:time] || Time.now.to_i
         
         query = defaults.collect{ |key, value| "#{key}=#{value}" }.join('&')
-        url = "/simple_captcha?code=#{simple_captcha_key}&#{query}"
+        url = "#{ENV['RAILS_RELATIVE_URL_ROOT']}/simple_captcha?code=#{simple_captcha_key}&#{query}"
         
         tag('img', :src => url, :alt => 'captcha')
       end


### PR DESCRIPTION
This plugin does not work when rails app is deployed into a subdirectory, rather than into the root of website (http://example.org/apps/ instead of http://example.org/).

In order to fix this issue it is necessary to use ENV["RAILS_RELATIVE_URL_ROOT"] when generating image url.
