### PR TITLE
use session_id at SimpleCaptcha::Utils::generate_key()

### DIFF
--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -106,9 +106,9 @@ module SimpleCaptcha #:nodoc
       
       def simple_captcha_key(key_name = nil)
         if key_name.nil?
-          session[:captcha] ||= SimpleCaptcha::Utils.generate_key(session[:id].to_s, 'captcha')
+          session[:captcha] ||= SimpleCaptcha::Utils.generate_key(session[:session_id].to_s, 'captcha')
         else
-          SimpleCaptcha::Utils.generate_key(session[:id].to_s, key_name)
+          SimpleCaptcha::Utils.generate_key(session[:session_id].to_s, key_name)
         end
       end 
   end


### PR DESCRIPTION
It is wasteful not to use this code at default.

``` ruby
      def simple_captcha_key(key_name = nil)
        if key_name.nil?
          session[:captcha] ||= SimpleCaptcha::Utils.generate_key(session[:id].to_s, 'captcha')
        else
          SimpleCaptcha::Utils.generate_key(session[:id].to_s, key_name)
        end
      end 
```

I want to change session[:id] into session[:session_id].
Then, we can use session_id at default and simple_capthca_data.key become more unique.
