### PR TITLE
Replace :git to :github

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ backward compatibility with previous versions of Rails.
 
 or
 
-  gem 'galetahub-simple_captcha', :require => 'simple_captcha', :git => 'git://github.com/galetahub/simple-captcha.git'
+  gem 'galetahub-simple_captcha', :require => 'simple_captcha', :github => 'galetahub/simple-captcha'
 
 ==Setup
 


### PR DESCRIPTION
Update installation instruction to use `:github` param instead of `:git`.
