### PR TITLE
Validation should be idempotent

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -57,6 +57,7 @@ and in the controller's action authenticate it as
 
   if simple_captcha_valid?
     do this
+    simple_captcha_passed!
   else
     do that
   end

--- a/lib/simple_captcha/active_record.rb
+++ b/lib/simple_captcha/active_record.rb
@@ -3,7 +3,7 @@ module SimpleCaptcha #:nodoc
     def self.included(base)
       base.extend(SingletonMethods)
     end
-    
+
     # To implement model based simple captcha use this method in the model as...
     #
     #  class User < ActiveRecord::Base
@@ -12,13 +12,13 @@ module SimpleCaptcha #:nodoc
     #
     #  end
     #
-    # Customize the error message by using :message, the default message is "Captcha did not match". 
+    # Customize the error message by using :message, the default message is "Captcha did not match".
     # As in the applications captcha is needed with a very few cases like signing up the new user, but
     # not every time you need to authenticate the captcha with @user.save. So as to maintain simplicity
     # here we have the explicit method to save the instace with captcha validation as...
     #
     # * to validate the instance
-    #  
+    #
     #  @user.valid_with_captcha?  # whene captcha validation is required.
     #
     #  @user.valid?               # when captcha validation is not required.
@@ -31,33 +31,32 @@ module SimpleCaptcha #:nodoc
     module SingletonMethods
       def apply_simple_captcha(options = {})
         options = { :add_to_base => false }.merge(options)
-                  
+
         class_attribute :simple_captcha_options
         self.simple_captcha_options = options
-        
+
         unless self.is_a?(ClassMethods)
           include InstanceMethods
           extend ClassMethods
-          
+
           attr_accessor :captcha, :captcha_key
         end
       end
     end
-    
+
     module ClassMethods
     end
-    
+
     module InstanceMethods
-    
+
       def valid_with_captcha?
         [valid?, is_captcha_valid?].all?
       end
-      
+
       def is_captcha_valid?
         return true if Rails.env.test?
 
         if captcha && captcha.upcase.delete(" ") == SimpleCaptcha::Utils::simple_captcha_value(captcha_key)
-          SimpleCaptcha::Utils::simple_captcha_passed!(captcha_key)
           return true
         else
           message = simple_captcha_options[:message] || I18n.t(self.class.model_name.downcase, :scope => [:simple_captcha, :message], :default => :default)
@@ -65,9 +64,14 @@ module SimpleCaptcha #:nodoc
           return false
         end
       end
-      
+
       def save_with_captcha
-        valid_with_captcha? && save(:validate => false)
+        if valid_with_captcha? && save(:validate => false)
+          SimpleCaptcha::Utils::simple_captcha_passed!(captcha_key)
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/lib/simple_captcha/controller.rb
+++ b/lib/simple_captcha/controller.rb
@@ -1,4 +1,4 @@
-module SimpleCaptcha #:nodoc 
+module SimpleCaptcha #:nodoc
   module ControllerHelpers #:nodoc
     # This method is to validate the simple captcha in controller.
     # It means when the captcha is controller based i.e. :object has not been passed to the method show_simple_captcha.
@@ -15,15 +15,18 @@ module SimpleCaptcha #:nodoc
     #  end
     def simple_captcha_valid?
       return true if Rails.env.test?
-      
+
       if params[:captcha]
         data = SimpleCaptcha::Utils::simple_captcha_value(params[:captcha_key] || session[:captcha])
         result = data == params[:captcha].delete(" ").upcase
-        SimpleCaptcha::Utils::simple_captcha_passed!(session[:captcha]) if result
         return result
       else
         return false
       end
+    end
+
+    def simple_captcha_passed!
+      SimpleCaptcha::Utils::simple_captcha_passed!(session[:captcha])
     end
   end
 end


### PR DESCRIPTION
`simple_captcha_valid?` references a bang method internally, removing the captcha key from the database. A second call to any validator will always return false. This commit changes the interface a little to remove the captcha key on model save, or manually via bang method in 'controller mode.'
