### PR TITLE
use correct gem name and homepage

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ backward compatibility with previous versions of Rails.
 
 or
 
-  gem 'simple_captcha', :git => 'git://github.com/galetahub/simple-captcha.git'
+  gem 'galetahub-simple_captcha', :git => 'git://github.com/galetahub/simple-captcha.git'
 
 ==Setup
 

--- a/simple_captcha.gemspec
+++ b/simple_captcha.gemspec
@@ -3,15 +3,15 @@ $:.push File.expand_path("../lib", __FILE__)
 require "simple_captcha/version"
 
 Gem::Specification.new do |s|
-  s.name = "simple_captcha"
+  s.name = "galetahub-simple_captcha"
   s.version = SimpleCaptcha::VERSION.dup
-  s.platform = Gem::Platform::RUBY 
+  s.platform = Gem::Platform::RUBY
   s.summary = "SimpleCaptcha is the simplest and a robust captcha plugin."
   s.description = "SimpleCaptcha is available to be used with Rails 3 or above and also it provides the backward compatibility with previous versions of Rails."
   s.authors = ["Pavlo Galeta", "Igor Galeta"]
   s.email = "galeta.igor@gmail.com"
-  s.homepage = "http://github.com/izzm/simple-captcha"
-  
+  s.homepage = "https://github.com/galetahub/simple-captcha"
+
   s.files = Dir["{lib}/**/*"] + ["Rakefile", "README.rdoc"]
   s.test_files = Dir["{test}/**/*"]
   s.extra_rdoc_files = ["README.rdoc"]


### PR DESCRIPTION
I think the correct gem name should be galetahub-simple_captcha. Changing its name to "simple_captcha" make it inconsistent to install from different source

I also found it confusing when clicking "Homepage" on rubygems.org redirects me to another github repository (http://github.com/izzm/simple-captcha)

We may need more inputs from @izzm for the reason of changing gem name.
