### PR TITLE
Fix FormBuilder error when no Sprockets installed.

### DIFF
--- a/lib/simple_captcha/form_builder.rb
+++ b/lib/simple_captcha/form_builder.rb
@@ -4,8 +4,10 @@ module SimpleCaptcha
       base.send(:include, SimpleCaptcha::ViewHelper)
       base.send(:include, SimpleCaptcha::FormBuilder::ClassMethods)
       base.send(:include, ActionView::Helpers)
-      base.send(:include, Sprockets::Helpers::RailsHelper)
-      base.send(:include, Sprockets::Helpers::IsolatedHelper)
+      if defined? Sprokets
+        base.send(:include, Sprockets::Helpers::RailsHelper)
+        base.send(:include, Sprockets::Helpers::IsolatedHelper)
+      end
       
       base.delegate :render, :session, :to => :template
     end


### PR DESCRIPTION
After merged #29, with Rails 3.0 and no Sprockets installed, we got an NameError:
`uninitialized constant SimpleCaptcha::FormBuilder::Sprockets`.

We can prevent including Sprockets::Helpers when they were not there.
