### PR TITLE
Change tmp_path default value to Dir::tmpdir.

### DIFF
--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -48,7 +48,7 @@ module SimpleCaptcha
 
   # tmp directory
   mattr_accessor :tmp_path
-  @@tmp_path = nil
+  @@tmp_path = Dir::tmpdir
 
   def self.add_image_style(name, params = [])
     SimpleCaptcha::ImageHelpers.image_styles.update(name.to_s => params)


### PR DESCRIPTION
The default value of `tmp_path` config option is `/tmp`, as describe in README.
However, current default is set to `nil`, which causes RuntimeError (cannot generate tempfile "") since `Tempfile#new` can not use nil as second argument.

Solution: set the default value to `Dif::tmpdir`.
