### PR TITLE
Compatibilty with Rails 4

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -208,6 +208,8 @@ You can change the CSS of the SimpleCaptcha DOM elements as per your need in thi
 ==I18n
 
   simple_captcha:
+    placeholder: "Enter the image value"
+    label: "Enter the code in the box:"
     message:
       default: "Secret Code did not match with the Image"
       user: "The secret Image and code were different"

--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -1,10 +1,7 @@
 module SimpleCaptcha
   class SimpleCaptchaData < ::ActiveRecord::Base
-    def self.rails3?
-      ::ActiveRecord::VERSION::MAJOR == 3
-    end
-
-    if rails3?
+    
+    if ::ActiveRecord::VERSION::MAJOR >= 3
       # Fixes deprecation warning in Rails 3.2:
       # DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead.
       self.table_name = "simple_captcha_data"


### PR DESCRIPTION
The code was checking for version only on Rails3, so if you use Rails4 it would try to use the self.table_name and crash. This correction is just to check if version is equal or greater than 3.

And also adding two translation messages that are missing in the README.rdoc
