### PR TITLE
introduce SimpleCaptcha.test_captcha

### DIFF
--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -47,6 +47,10 @@ module SimpleCaptcha
   mattr_accessor :point_size
   @@point_size = 22
 
+  # the expected captcha value for test
+  mattr_accessor :test_captcha
+  @@test_captcha = 'test'
+
   def self.add_image_style(name, params = [])
     SimpleCaptcha::ImageHelpers.image_styles.update(name.to_s => params)
   end

--- a/lib/simple_captcha/controller.rb
+++ b/lib/simple_captcha/controller.rb
@@ -14,7 +14,7 @@ module SimpleCaptcha #:nodoc
     #   redirect_to :action => "myaction"
     #  end
     def simple_captcha_valid?
-      return true if Rails.env.test?
+      return true if Rails.env.test? and params[:captcha] == SimpleCaptcha.test_captcha
       
       if params[:captcha]
         data = SimpleCaptcha::Utils::simple_captcha_value(params[:captcha_key] || session[:captcha])


### PR DESCRIPTION
hi Galeta,

currently `simple_captcha_valid?` always returns true in the TEST environment, however there are cases we hope to test the verification logic for captcha, maybe it would be better to allow users setting a special captcha value which always true in the TEST environment, but regard any other value as false.

Regards.
